### PR TITLE
Added CheckUserMemberOfGroup in service layer

### DIFF
--- a/controllers/group_controller.go
+++ b/controllers/group_controller.go
@@ -39,7 +39,7 @@ func AppendMembersToGroup(ctx *gin.Context) {
 	userIdInterface, _ := ctx.Get("userId")
 	userID, _ := userIdInterface.(uuid.UUID)
 
-	// Check user is autorized to append users to group
+	// Check user is authorized to append users to group
 	isMember, err := service.CheckUserMemberOfGroup(ctx, userID, req.GroupID)
 	if !isMember {
 		SendResponse(ctx, 401, nil, "", errors.New("unauthorized for group append"))
@@ -79,7 +79,7 @@ func GetGroupMembers(ctx *gin.Context) {
 	groupIDStr := ctx.Param("groupId")
 	groupID, _ := uuid.Parse(groupIDStr)
 
-	// Check user is autorized to see members of the group
+	// Check user is authorized to see members of the group
 	isMember, err := service.CheckUserMemberOfGroup(ctx, userID, groupID)
 	if !isMember {
 		SendResponse(ctx, 401, nil, "", errors.New("unauthorized for group view"))

--- a/controllers/group_controller.go
+++ b/controllers/group_controller.go
@@ -38,7 +38,19 @@ func AppendMembersToGroup(ctx *gin.Context) {
 
 	userIdInterface, _ := ctx.Get("userId")
 	userID, _ := userIdInterface.(uuid.UUID)
-	err := service.AddMembersToGroup(ctx, req, userID)
+
+	// Check user is autorized to append users to group
+	isMember, err := service.CheckUserMemberOfGroup(ctx, userID, req.GroupID)
+	if !isMember {
+		SendResponse(ctx, 401, nil, "", errors.New("unauthorized for group append"))
+		return
+	}
+	if err != nil {
+		SendResponse(ctx, 500, nil, "Failed to append user", errors.New("failed to append user"))
+		return
+	}
+
+	err = service.AddMembersToGroup(ctx, req, userID)
 	if err != nil {
 		SendResponse(ctx, 500, nil, "Failed to append user", errors.New("failed to append user"))
 		return
@@ -66,6 +78,18 @@ func GetGroupMembers(ctx *gin.Context) {
 
 	groupIDStr := ctx.Param("groupId")
 	groupID, _ := uuid.Parse(groupIDStr)
+
+	// Check user is autorized to see members of the group
+	isMember, err := service.CheckUserMemberOfGroup(ctx, userID, groupID)
+	if !isMember {
+		SendResponse(ctx, 401, nil, "", errors.New("unauthorized for group view"))
+		return
+	}
+	if err != nil {
+		SendResponse(ctx, 500, nil, "Failed to fetch Group members", errors.New("failed to fetch group members"))
+		return
+	}
+
 	groups, err := service.GetGroupMembers(ctx, userID, groupID)
 	if err != nil {
 		SendResponse(ctx, 500, nil, "Failed to fetch Group members", errors.New("failed to fetch group members"))

--- a/db/query/groups.sql
+++ b/db/query/groups.sql
@@ -28,3 +28,10 @@ SELECT u.id, u.name, u.username, u.public_key as "publicKey"
 FROM users u
 JOIN group_list gl ON u.id = gl.user_id
 WHERE gl.grouping_id = $1;
+
+
+-- name: CheckUserMemberOfGroup :one
+SELECT EXISTS (
+  SELECT 1 FROM group_list
+  WHERE user_id = $1 AND grouping_id = $2
+) as "exists";

--- a/db/sqlc/groups.sql.go
+++ b/db/sqlc/groups.sql.go
@@ -31,6 +31,25 @@ func (q *Queries) AddMemberToGroup(ctx context.Context, arg AddMemberToGroupPara
 	return err
 }
 
+const checkUserMemberOfGroup = `-- name: CheckUserMemberOfGroup :one
+SELECT EXISTS (
+  SELECT 1 FROM group_list
+  WHERE user_id = $1 AND grouping_id = $2
+) as "exists"
+`
+
+type CheckUserMemberOfGroupParams struct {
+	UserID     uuid.UUID `json:"user_id"`
+	GroupingID uuid.UUID `json:"grouping_id"`
+}
+
+func (q *Queries) CheckUserMemberOfGroup(ctx context.Context, arg CheckUserMemberOfGroupParams) (bool, error) {
+	row := q.db.QueryRowContext(ctx, checkUserMemberOfGroup, arg.UserID, arg.GroupingID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const createGroup = `-- name: CreateGroup :exec
 WITH new_group AS (
   INSERT INTO groupings (name, created_by)

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -16,6 +16,7 @@ type Querier interface {
 	AddFolderAccess(ctx context.Context, arg AddFolderAccessParams) error
 	AddMemberToGroup(ctx context.Context, arg AddMemberToGroupParams) error
 	AddToAccessList(ctx context.Context, arg AddToAccessListParams) (uuid.UUID, error)
+	CheckUserMemberOfGroup(ctx context.Context, arg CheckUserMemberOfGroupParams) (bool, error)
 	// sql/create_credential.sql
 	CreateCredential(ctx context.Context, arg CreateCredentialParams) (uuid.UUID, error)
 	CreateEncryptedData(ctx context.Context, arg CreateEncryptedDataParams) (uuid.UUID, error)

--- a/repository/group_repository.go
+++ b/repository/group_repository.go
@@ -56,3 +56,16 @@ func GetGroupMembers(ctx *gin.Context, groupID uuid.UUID) ([]db.GetGroupMembersR
 	}
 	return users, nil
 }
+
+func CheckUserMemberOfGroup(ctx *gin.Context, userID uuid.UUID, groupID uuid.UUID) (bool, error) {
+	args := db.CheckUserMemberOfGroupParams{
+		UserID:     userID,
+		GroupingID: groupID,
+	}
+	isMember, err := database.Q.CheckUserMemberOfGroup(ctx, args)
+	if err != nil {
+		logger.Errorf(err.Error())
+		return false, err
+	}
+	return isMember, nil
+}

--- a/services/group_service.go
+++ b/services/group_service.go
@@ -30,3 +30,8 @@ func GetGroupMembers(ctx *gin.Context, userID uuid.UUID, groupId uuid.UUID) ([]d
 	users, err := repository.GetGroupMembers(ctx, groupId)
 	return users, err
 }
+
+func CheckUserMemberOfGroup(ctx *gin.Context, userID uuid.UUID, groupID uuid.UUID) (bool, error) {
+	isMember, err := repository.CheckUserMemberOfGroup(ctx, userID, groupID)
+	return isMember, err
+}


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/Add-CheckGroupMember-in-group-service-layer-40a260d6c692423fbf736436f6202c7e?pvs=4)

### Summary 
When a user makes API call to see members of a group, we need to make sure that the user is already a member of the group. If he/she is not a member we should send a 401 (unauthorized status code)


Note: I have tested the endpoints that makes use of this 